### PR TITLE
filter for squads that are available to the user

### DIFF
--- a/R/getPlayerIterationAverages.R
+++ b/R/getPlayerIterationAverages.R
@@ -25,6 +25,7 @@ getPlayerIterationAverages <- function (iteration, token) {
   # get squads for given iterationId
   squads <- .squadNames(iteration = iteration, token = token)
   squadIds <- squads %>%
+    dplyr::filter(access == TRUE) %>%
     dplyr::pull(id) %>%
     base::unique()
 


### PR DESCRIPTION
Previously, the `getPlayerIterationAverages()` function queried the squads endpoint and then iterated over all squads returned. Now the returned squad list is filtered for squads the user has access to prior to iterating.