### PR TITLE
remove duplicates from squads and players before merging

### DIFF
--- a/R/getEvents.R
+++ b/R/getEvents.R
@@ -44,12 +44,14 @@ getEvents <- function (matches, token) {
   # apply .playerNames function to a set of iterations
   players <-
     purrr::map_df(iterations,
-                  ~ .playerNames(iteration = ., token = token))
+                  ~ .playerNames(iteration = ., token = token)) %>%
+    base::unique()
 
   # apply .squadNames function to a set of iterations
   squads <-
     purrr::map_df(iterations,
-                  ~ .squadNames(iteration = ., token = token))
+                  ~ .squadNames(iteration = ., token = token)) %>%
+    base::unique()
 
   # get kpi names
   kpis <- .kpis(token = token, scope = "event")


### PR DESCRIPTION
When getting event data for multiple matches from different iterations of the same competition, a list of squads containing duplicates is returned. This causes the duplication of events when merging events squads.

To address this issue alongside other potential issues of the same nature with other returned data frames, duplicates from the squads and players data frames will be removed.