### PR TITLE
explicitly select relevant columns only

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -475,7 +475,8 @@
   # convert to dataframe
   temp <-
     jsonlite::fromJSON(httr::content(response, "text", encoding = "UTF-8"))$data %>%
-    jsonlite::flatten()
+    jsonlite::flatten() %>%
+    dplyr::select(id, name)
 
   # return squads
   return(temp)


### PR DESCRIPTION
A fix was applied to the `.kpis()` helper function. The required columns id and name are now selected explicitly and the newly added columns are ignored.