### PR TITLE
prevent players without scorings form being ignored

### DIFF
--- a/R/getPlayerIterationAverages.R
+++ b/R/getPlayerIterationAverages.R
@@ -51,7 +51,7 @@ getPlayerIterationAverages <- function (iteration, token) {
 
   # unnest scorings
   averages <- averages_raw %>%
-    tidyr::unnest("kpis") %>%
+    tidyr::unnest("kpis", keep_empty = TRUE) %>%
     dplyr::select(
       iterationId,
       squadId,
@@ -75,7 +75,9 @@ getPlayerIterationAverages <- function (iteration, token) {
       values_fn = base::sum
     ) %>%
     # filter for non NA columns that were created by full join
-    dplyr::filter(base::is.na(playerId) == FALSE)
+    dplyr::filter(base::is.na(playerId) == FALSE) %>%
+    # remove the "NA" column if it exists
+    dplyr::select(-dplyr::matches("^NA$"))
 
   # merge with other data
   averages <- averages %>%

--- a/R/getPlayerMatchsums.R
+++ b/R/getPlayerMatchsums.R
@@ -97,15 +97,9 @@ getPlayerMatchsums <- function (matches, token) {
       ),
       recursive = FALSE)
 
-    # detect non-empty scorings column
-    list <- base::sapply(temp$kpis, length) > 0
-
-    # filter and add context data
-    temp <- temp[list,]
-
     # unnest scorings
     temp <- temp %>%
-      tidyr::unnest("kpis") %>%
+      tidyr::unnest("kpis", keep_empty = TRUE) %>%
       dplyr::select(
         "playerId" = "id",
         "position",
@@ -127,6 +121,8 @@ getPlayerMatchsums <- function (matches, token) {
       ) %>%
       # filter for non NA columns that were created by full join
       dplyr::filter(base::is.na(playerId) == FALSE) %>%
+      # remove the "NA" column if it exists
+      dplyr::select(-dplyr::matches("^NA$")) %>%
       dplyr::mutate(
         # add matchId
         matchId = dict$matchId,


### PR DESCRIPTION
For the `getPlayerMatchsums()` function, a piece of code that was removing players without registered scorings was removed. Also the `dplyr::unnest()`function argument `keep_empty = TRUE`had to be set. This caused a `NA` column after `dplyr::pivot_wider()`. This had to be dropped using `dplyr::select()`.

For the `getPlayerIterationAverages()` function, the `dplyr::unnest()`function argument `keep_empty = TRUE`had to be set. This caused a `NA` column after `dplyr::pivot_wider()`. This had to be dropped using `dplyr::select()`.