### PR TITLE
add playerName back in after previously removing it

### DIFF
--- a/R/getPlayerIterationAverages.R
+++ b/R/getPlayerIterationAverages.R
@@ -83,7 +83,7 @@ getPlayerIterationAverages <- function (iteration, token) {
   averages <- averages %>%
     dplyr::left_join(dplyr::select(squads, id, squadName = name),
                      by = c("squadId" = "id")) %>%
-    dplyr::left_join(dplyr::select(players, id, firstname, lastname, birthdate, birthplace, leg),
+    dplyr::left_join(dplyr::select(players, id, playerName = commonname, firstname, lastname, birthdate, birthplace, leg),
                      by = c("playerId" = "id")) %>%
     dplyr::left_join(dplyr::select(iterations, id, competitionName, season),
                      by = c("iterationId" = "id"))
@@ -96,6 +96,7 @@ getPlayerIterationAverages <- function (iteration, token) {
     "squadId",
     "squadName",
     "playerId",
+    "playerName",
     "firstname",
     "lastname",
     "birthdate",

--- a/R/getPlayerMatchsums.R
+++ b/R/getPlayerMatchsums.R
@@ -67,7 +67,7 @@ getPlayerMatchsums <- function (matches, token) {
   # apply playerNames function to a set of iterations
   players <-
     purrr::map_df(iterations, ~ .playerNames(iteration = ., token = token)) %>%
-    dplyr::select(id, firstname, lastname, birthdate, birthplace, leg) %>%
+    dplyr::select(id, playerName = commonname, firstname, lastname, birthdate, birthplace, leg) %>%
     base::unique()
 
   # apply squadNames function to a set of iterations
@@ -164,7 +164,7 @@ getPlayerMatchsums <- function (matches, token) {
       by = c("squadId" = "id")
     ) %>%
     dplyr::left_join(
-      dplyr::select(players, id, firstname, lastname, birthdate, birthplace, leg),
+      dplyr::select(players, id, playerName, firstname, lastname, birthdate, birthplace, leg),
       by = c("playerId" = "id")
     ) %>%
     # fix some column names
@@ -186,6 +186,7 @@ getPlayerMatchsums <- function (matches, token) {
     "squadId",
     "squadName",
     "playerId",
+    "playerName",
     "firstname",
     "lastname",
     "birthdate",


### PR DESCRIPTION
With a previous commit, the column "playerName" was replaced by "firstname" and "lastname". However, as for dome players, firstname and/or lastname are Null, the playerName had to be added back in.