### PR TITLE
Do not create empty column for `duelPlayerName` if it doesn't exist. …

### DIFF
--- a/R/getEvents.R
+++ b/R/getEvents.R
@@ -241,7 +241,6 @@ getEvents <- function (
     "dribblePlayerId",
     "duelDuelType",
     "duelPlayerId",
-    "duelPlayerName",
     "opponentCoordinatesX",
     "opponentCoordinatesY",
     "opponentAdjCoordinatesX",


### PR DESCRIPTION
…Let this be created when joining `duelPlayerId` with `players` dataframe.